### PR TITLE
changed log formatter to use logger name instead of filename

### DIFF
--- a/aw_core/log.py
+++ b/aw_core/log.py
@@ -70,7 +70,7 @@ def _create_file_handler(name, testing=False, log_json=False) -> logging.Handler
 
 
 def _create_human_formatter() -> logging.Formatter:
-    return logging.Formatter('%(asctime)-15s [%(levelname)-5s]: %(message)s (%(filename)s:%(lineno)s)')
+    return logging.Formatter('%(asctime)-15s [%(levelname)-5s]: %(message)s  (%(name)s:%(lineno)s)')
 
 
 def _create_json_formatter() -> logging.Formatter:

--- a/aw_core/log.py
+++ b/aw_core/log.py
@@ -11,12 +11,12 @@ from . import dirs
 log_file_path = None
 
 
-def get_log_file_path() -> Optional[str]:
+def get_log_file_path() -> Optional[str]:  # pragma: no cover
     return log_file_path
 
 
 def setup_logging(name: str, testing=False, verbose=False,
-                  log_stderr=True, log_file=False, log_file_json=False):
+                  log_stderr=True, log_file=False, log_file_json=False):  # pragma: no cover
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG if verbose else logging.INFO)
 
@@ -26,28 +26,28 @@ def setup_logging(name: str, testing=False, verbose=False,
         root_logger.addHandler(_create_file_handler(name, testing=testing, log_json=log_file_json))
 
 
-def _get_latest_log_files(name, testing=False) -> List[str]:
+def _get_latest_log_files(name, testing=False) -> List[str]:  # pragma: no cover
     """Returns a list with the filenames (not full paths) of all available logfiles for `name` sorted by latest first."""
     files = filter(lambda filename: name in filename, os.listdir(dirs.get_log_dir()))
     files = filter(lambda filename: "testing" in filename if testing else "testing" not in filename, files)
     return sorted(files, reverse=True)
 
 
-def get_latest_log_file(name, testing=False) -> Optional[str]:
+def get_latest_log_file(name, testing=False) -> Optional[str]:  # pragma: no cover
     """Returns the filename of the last logfile with `name`.
        Useful when you want to read the logfile of another ActivityWatch service."""
     last_logs = _get_latest_log_files(name, testing=testing)
     return last_logs[0] if last_logs else None
 
 
-def _create_stderr_handler() -> logging.Handler:
+def _create_stderr_handler() -> logging.Handler:  # pragma: no cover
     stderr_handler = logging.StreamHandler(stream=sys.stderr)
     stderr_handler.setFormatter(_create_human_formatter())
 
     return stderr_handler
 
 
-def _create_file_handler(name, testing=False, log_json=False) -> logging.Handler:
+def _create_file_handler(name, testing=False, log_json=False) -> logging.Handler:  # pragma: no cover
     log_dir = dirs.get_log_dir()
 
     # Set logfile path and name
@@ -69,11 +69,11 @@ def _create_file_handler(name, testing=False, log_json=False) -> logging.Handler
     return fh
 
 
-def _create_human_formatter() -> logging.Formatter:
+def _create_human_formatter() -> logging.Formatter:  # pragma: no cover
     return logging.Formatter('%(asctime)-15s [%(levelname)-5s]: %(message)s  (%(name)s:%(lineno)s)')
 
 
-def _create_json_formatter() -> logging.Formatter:
+def _create_json_formatter() -> logging.Formatter:  # pragma: no cover
     supported_keys = [
         'asctime',
         # 'created',


### PR DESCRIPTION
This will work better when all loggers are created in the recommended way: `logger = logging.getLogger(__name__)`

Kind of funny how I didn't realize until now that this is how it has always been recommended to create loggers.