### PR TITLE
Log events that reach into the future

### DIFF
--- a/aw_datastore/datastore.py
+++ b/aw_datastore/datastore.py
@@ -89,13 +89,15 @@ class Bucket:
         if len(last_event_list) > 0:
             last_event = last_event_list[0]
 
+        now = datetime.now(tz=timezone.utc)
+
         inserted = None  # type: Optional[Event]
 
         # Call insert
         if isinstance(events, Event):
             oldest_event = events
-            if events.timestamp + events.duration > datetime.now(tz=timezone.utc):
-                self.logger.warning("Event inserted into bucket {} reaches into the future. Event data: {}".format(self.bucket_id, str(events)))
+            if events.timestamp + events.duration > now:
+                self.logger.warning("Event inserted into bucket {} reaches into the future. Current UTC time: {}. Event data: {}".format(self.bucket_id, str(now), str(events)))
             inserted = self.ds.storage_strategy.insert_one(self.bucket_id, events)
             assert inserted
         elif isinstance(events, list):
@@ -104,8 +106,8 @@ class Bucket:
             else:
                 oldest_event = None
             for event in events:
-                if event.timestamp + event.duration > datetime.now(tz=timezone.utc):
-                    self.logger.warning("Event inserted into bucket {} reaches into the future. Event data: {}".format(self.bucket_id, str(event)))
+                if event.timestamp + event.duration > now:
+                    self.logger.warning("Event inserted into bucket {} reaches into the future. Current UTC time: {}. Event data: {}".format(self.bucket_id, str(now), str(event)))
             self.ds.storage_strategy.insert_many(self.bucket_id, events)
         else:
             raise TypeError

--- a/aw_datastore/datastore.py
+++ b/aw_datastore/datastore.py
@@ -94,6 +94,8 @@ class Bucket:
         # Call insert
         if isinstance(events, Event):
             oldest_event = events
+            if events.timestamp + events.duration > datetime.now(tz=timezone.utc):
+                self.logger.warning("Event inserted into bucket {} reaches into the future. Event data: {}".format(self.bucket_id, str(events)))
             inserted = self.ds.storage_strategy.insert_one(self.bucket_id, events)
             assert inserted
         elif isinstance(events, list):
@@ -101,6 +103,9 @@ class Bucket:
                 oldest_event = sorted(events, key=lambda k: k['timestamp'])[0]
             else:
                 oldest_event = None
+            for event in events:
+                if event.timestamp + event.duration > datetime.now(tz=timezone.utc):
+                    self.logger.warning("Event inserted into bucket {} reaches into the future. Event data: {}".format(self.bucket_id, str(event)))
             self.ds.storage_strategy.insert_many(self.bucket_id, events)
         else:
             raise TypeError


### PR DESCRIPTION
Hello,

I made the changes suggested here: https://github.com/ActivityWatch/aw-server/pull/40

I decided it was cleaner to implement the logging in aw_datastore rather than aw-server. This way, events and heartbeats will get logged in the same place.

I did notice the aw-server tests generate a lot of warnings now... I "fixed" this in the other PR by changing the event timestamps/start times. Let me know if this is important to you and I can change around my other PR to just incorporate the test changes. Otherwise feel free to close it if you like what I've done here.

For reference, this change was implemented to help resolve this issue: https://github.com/ActivityWatch/activitywatch/issues/153