### PR TITLE
Fix json serialization of event ids

### DIFF
--- a/aw_datastore/__init__.py
+++ b/aw_datastore/__init__.py
@@ -14,8 +14,8 @@ def get_storage_methods() -> Dict[str, Callable[[Any], storages.AbstractStorage]
         MemoryStorage.sid: MemoryStorage,
     }  # type: Dict[str, Callable[[Any], storages.AbstractStorage]]
 
-    # MongoDB is not supported on Windows or macOS
-    if _platform.system() == "Linux":  # pragma: no branch
+    # MongoDB is not supported on Windows
+    if _platform.system() in ("Linux", "Darwin"):  # pragma: no branch
         try:
             import pymongo
             methods[MongoDBStorage.sid] = MongoDBStorage

--- a/aw_datastore/storages/mongodb.py
+++ b/aw_datastore/storages/mongodb.py
@@ -111,7 +111,7 @@ class MongoDBStorage(AbstractStorage):
         dict_event = event.copy()
         dict_event = self._transform_event(dict_event)
         returned = self.db[bucket]["events"].insert_one(dict_event)
-        event.id = returned.inserted_id
+        event.id = str(returned.inserted_id)
         return event
 
     def insert_many(self, bucket: str, events: List[Event]):


### PR DESCRIPTION
MongDB returns ObjectId instance as created event id, that has to be turned to string to be serializable.

Fixes [#200](https://github.com/ActivityWatch/activitywatch/issues/200)

Also enables MongoDB support for macOS, is there a reason to keep it disabled?