### PR TITLE
Simplify filter_keyvals code

### DIFF
--- a/aw_transform/filter_keyvals.py
+++ b/aw_transform/filter_keyvals.py
@@ -12,9 +12,9 @@ def filter_keyvals(events: List[Event], key: str, vals: List[str], exclude=False
         return key in event.data and event.data[key] in vals
 
     if exclude:
-      return [e for e in events if not predicate(e)]
+        return [e for e in events if not predicate(e)]
     else:
-      return [e for e in events if predicate(e)]
+        return [e for e in events if predicate(e)]
 
 
 def filter_keyvals_regex(events: List[Event], key: str, regex: str) -> List[Event]:
@@ -23,4 +23,4 @@ def filter_keyvals_regex(events: List[Event], key: str, regex: str) -> List[Even
     def predicate(event):
         return bool(r.findall(event.data[key]))
 
-    return list(filter(lambda e: predicate(e), events))
+    return [e for e in events if predicate(e)]

--- a/aw_transform/filter_keyvals.py
+++ b/aw_transform/filter_keyvals.py
@@ -9,15 +9,12 @@ logger = logging.getLogger(__name__)
 
 def filter_keyvals(events: List[Event], key: str, vals: List[str], exclude=False) -> List[Event]:
     def predicate(event):
-        for val in vals:
-            if key in event.data and val == event.data[key]:
-                return True
-        return False
+        return key in event.data and event.data[key] in vals
 
     if exclude:
-        return list(filter(lambda e: not predicate(e), events))
+      return [e for e in events if not predicate(e)]
     else:
-        return list(filter(lambda e: predicate(e), events))
+      return [e for e in events if predicate(e)]
 
 
 def filter_keyvals_regex(events: List[Event], key: str, regex: str) -> List[Event]:


### PR DESCRIPTION
Especially the predicate function seems much cleaner and easier to me when using `event.data[key] in vals` instead of a for loop.
The second change probably depends on the reader.


Can be tested here: https://repl.it/repls/FragrantGrubbyStatistic