### PR TITLE
Fixed issue in flooding algorithm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
  - mongodb
 
 before_install:
- - "pip install -r requirements-dev.txt"
+ - "pip install -U -r requirements-dev.txt"
  - "pip install pymongo"
 
 install:

--- a/aw_analysis/query2.py
+++ b/aw_analysis/query2.py
@@ -117,7 +117,7 @@ class QFunction(QToken):
         call_args = [datastore, namespace]
         for arg in self.args:
             call_args.append(arg.interpret(datastore, namespace))
-        logger.debug("Arguments for functioncall to {} is {}".format(self.name, call_args))
+        # logger.debug("Arguments for functioncall to {} is {}".format(self.name, call_args))
         try:
             result = query2_functions[self.name](*call_args)  # type: ignore
         except TypeError:
@@ -355,7 +355,7 @@ def parse(line, namespace):
 
 def interpret(var, val, namespace, datastore):
     namespace[var.name] = val.interpret(datastore, namespace)
-    logger.debug("Set {} to {}".format(var.name, namespace[var.name]))
+    # logger.debug("Set {} to {}".format(var.name, namespace[var.name]))
 
 
 def get_return(namespace):
@@ -374,7 +374,7 @@ def query(name: str, query: str, starttime: datetime, endtime: datetime, datasto
     for statement in query_stmts:
         statement = statement.strip()
         if statement:
-            logger.debug("Parsing: " + statement)
+            # logger.debug("Parsing: " + statement)
             var, val = parse(statement, namespace)
             interpret(var, val, namespace, datastore)
 

--- a/aw_transform/flood.py
+++ b/aw_transform/flood.py
@@ -18,19 +18,35 @@ def flood(events: List[Event], pulsetime: float=5) -> List[Event]:
     events = deepcopy(events)
     events = sorted(events, key=lambda e: e.timestamp)
 
-    warned_about_negative_gap = False
+    warned_about_negative_gap_safe = False
+    warned_about_negative_gap_unsafe = False
 
     for e1, e2 in zip(events[:-1], events[1:]):
         gap = e2.timestamp - (e1.timestamp + e1.duration)
 
-        # Sanity check
-        if gap < timedelta(0) and not warned_about_negative_gap:
-            logger.warning("Gap was of negative duration ({}s). This error will only show once per batch.".format(gap.total_seconds()))
-            # logger.warning("Event 1 (id {}): {} {}".format(e1.id, e1.timestamp, e1.duration))
-            # logger.warning("Event 2 (id {}): {} {}".format(e2.id, e2.timestamp, e2.duration))
-            warned_about_negative_gap = True
+        # Sanity check in case events overlap
+        if gap < timedelta(0):
+            if e1.data == e2.data:
+                # Events with negative gap but same data safely be merged
+                start = min(e1.timestamp, e2.timestamp)
+                end = max(e1.timestamp + e1.duration, e2.timestamp + e2.duration)
+                e1.timestamp = start
+                e1.duration = (end - start)
+                e2.timestamp = end
+                e2.duration = timedelta(0)
+                if not warned_about_negative_gap_safe:
+                    logger.warning("Gap was of negative duration ({}s), but could be safely merged. This error will only show once per batch.".format(gap.total_seconds()))
+                    warned_about_negative_gap_safe = True
+                gap = e2.timestamp - (e1.timestamp + e1.duration)
+            elif not warned_about_negative_gap_unsafe:
+                # Events with negative gap but differing data cannot be merged
+                logger.warning("Gap was of negative duration ({}s), and could NOT be safely merged. This error will only show once per batch.".format(gap.total_seconds()))
+                warned_about_negative_gap_unsafe = True
+                # logger.warning("Event 1 (id {}): {} {}".format(e1.id, e1.timestamp, e1.duration))
+                # logger.warning("Event 2 (id {}): {} {}".format(e2.id, e2.timestamp, e2.duration))
 
-        if gap <= timedelta(seconds=pulsetime):
+        # if timedelta(0) <= gap <= timedelta(seconds=pulsetime):
+        if timedelta(0) < gap <= timedelta(seconds=pulsetime):
             e2_end = e2.timestamp + e2.duration
 
             # Prioritize flooding from the longer event

--- a/aw_transform/flood.py
+++ b/aw_transform/flood.py
@@ -15,8 +15,15 @@ def flood(events: List[Event], pulsetime: float=5) -> List[Event]:
 
     Copied here from: https://github.com/ActivityWatch/aw-analysis/blob/7da1f2cd8552f866f643501de633d74cdecab168/aw_analysis/flood.py
     """
+    # NOTE: This algorithm has a lot of smaller details that need to be
+    #       carefully considered by anyone wishing to edit it, see:
+    #        - https://github.com/ActivityWatch/aw-core/pull/73
+
     events = deepcopy(events)
     events = sorted(events, key=lambda e: e.timestamp)
+
+    # If negative gaps are smaller than this, prune them to become zero
+    negative_gap_trim_thres = timedelta(seconds=0.1)
 
     warned_about_negative_gap_safe = False
     warned_about_negative_gap_unsafe = False
@@ -24,29 +31,26 @@ def flood(events: List[Event], pulsetime: float=5) -> List[Event]:
     for e1, e2 in zip(events[:-1], events[1:]):
         gap = e2.timestamp - (e1.timestamp + e1.duration)
 
-        # Sanity check in case events overlap
-        if gap < timedelta(0):
-            if e1.data == e2.data:
-                # Events with negative gap but same data safely be merged
-                start = min(e1.timestamp, e2.timestamp)
-                end = max(e1.timestamp + e1.duration, e2.timestamp + e2.duration)
-                e1.timestamp = start
-                e1.duration = (end - start)
-                e2.timestamp = end
-                e2.duration = timedelta(0)
-                if not warned_about_negative_gap_safe:
-                    logger.warning("Gap was of negative duration ({}s), but could be safely merged. This error will only show once per batch.".format(gap.total_seconds()))
-                    warned_about_negative_gap_safe = True
-                gap = e2.timestamp - (e1.timestamp + e1.duration)
-            elif not warned_about_negative_gap_unsafe:
-                # Events with negative gap but differing data cannot be merged
-                logger.warning("Gap was of negative duration ({}s), and could NOT be safely merged. This error will only show once per batch.".format(gap.total_seconds()))
-                warned_about_negative_gap_unsafe = True
-                # logger.warning("Event 1 (id {}): {} {}".format(e1.id, e1.timestamp, e1.duration))
-                # logger.warning("Event 2 (id {}): {} {}".format(e2.id, e2.timestamp, e2.duration))
+        if not gap:
+            continue
 
-        # if timedelta(0) <= gap <= timedelta(seconds=pulsetime):
-        if timedelta(0) < gap <= timedelta(seconds=pulsetime):
+        # Sanity check in case events overlap
+        if gap < timedelta(0) and e1.data == e2.data:
+            # Events with negative gap but same data can safely be merged
+            start = min(e1.timestamp, e2.timestamp)
+            end = max(e1.timestamp + e1.duration, e2.timestamp + e2.duration)
+            e1.timestamp, e1.duration = start, (end - start)
+            e2.timestamp, e2.duration = end, timedelta(0)
+            if not warned_about_negative_gap_safe:
+                logger.warning("Gap was of negative duration but could be safely merged ({}s). This message will only show once per batch.".format(gap.total_seconds()))
+                warned_about_negative_gap_safe = True
+        elif gap < -negative_gap_trim_thres and not warned_about_negative_gap_unsafe:
+            # Events with negative gap but differing data cannot be merged safely
+            logger.warning("Gap was of negative duration and could NOT be safely merged ({}s). This warning will only show once per batch.".format(gap.total_seconds()))
+            warned_about_negative_gap_unsafe = True
+            # logger.warning("Event 1 (id {}): {} {}".format(e1.id, e1.timestamp, e1.duration))
+            # logger.warning("Event 2 (id {}): {} {}".format(e2.id, e2.timestamp, e2.duration))
+        elif -negative_gap_trim_thres < gap <= timedelta(seconds=pulsetime):
             e2_end = e2.timestamp + e2.duration
 
             # Prioritize flooding from the longer event

--- a/tests/test_flood.py
+++ b/tests/test_flood.py
@@ -59,10 +59,18 @@ def test_flood_negative_gap_same_data():
 
 def test_flood_negative_gap_differing_data():
     events = [
-        Event(timestamp=now, duration=100, data={"b": 1}),
         Event(timestamp=now, duration=5, data={"a": 0}),
+        Event(timestamp=now, duration=100, data={"b": 1}),
     ]
     flooded = flood(events)
-    print(sum((e.duration for e in events), timedelta(0)))
-    print(flooded)
     assert flooded == events
+
+
+def test_flood_negative_small_gap_differing_data():
+    events = [
+        Event(timestamp=now, duration=100, data={"b": 1}),
+        Event(timestamp=now + 99.99 * td1s, duration=100, data={"a": 0}),
+    ]
+    flooded = flood(events)
+    duration = sum((e.duration for e in flooded), timedelta(0))
+    assert duration == timedelta(seconds=100 + 99.99)

--- a/tests/test_flood.py
+++ b/tests/test_flood.py
@@ -4,7 +4,7 @@ from aw_core.models import Event
 from aw_transform import flood
 
 
-now = datetime.now().astimezone(timezone.utc)
+now = datetime.now(tz=timezone.utc)
 td1s = timedelta(seconds=1)
 
 


### PR DESCRIPTION
I discovered a pretty severe bug that caused >1h of activity to not show up on the dashboard.

I narrowed it down to an issue in the afk bucket:

![image](https://user-images.githubusercontent.com/1405370/51036191-aa771580-15ac-11e9-966e-5d86a936eba9.png)

The logs complained upon query:

    [WARNING]: Gap was of negative duration (-4815.292s). This error will only show once per batch.

The two first events begin at the exact same time, which causes the negative gap to occur when the following is computed `gap = e2.timestamp - (e1.timestamp + e1.duration)`. The problem arose when the flooding were to take place, since it happened *despite* the negative gap being detected, which it should not, leading to shortening of the longer event in my case to the end of the shorter event.

I also realized that if two events had a negative gap and contained the same data, they can be safely merged into the same event.
