### PR TITLE
Set jsonschema version to 2.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build test benchmark typecheck typecheck-strict clean
 
-pip_install_args := . -r requirements.txt --upgrade
+pip_install_args := . -r requirements.txt
 
 ifdef DEV
 pip_install_args := --editable $(pip_install_args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jsonschema
+jsonschema==2.6.0
 peewee==3.*
 strict-rfc3339
 appdirs>=1.4.0


### PR DESCRIPTION
Fixes aw-server not starting on Windows when built with PyInstaller

https://github.com/pyinstaller/pyinstaller/issues/4100