### PR TITLE
WIP: Migrate peewee users to sqlite

### DIFF
--- a/aw_core/config.py
+++ b/aw_core/config.py
@@ -22,9 +22,11 @@ def load_config(appname, default_config):
         with open(config_file_path, 'r') as f:
             config.read_file(f)
 
+    if config["server-testing"]["storage"] == "peewee":
+        logger.info("Config file database migrated to sqlite")
+        config["server-testing"]["storage"] = "sqlite"
     # Overwrite current config file (necessary in case new default would be added)
     save_config(appname, config)
-
     return config
 
 

--- a/aw_datastore/migration.py
+++ b/aw_datastore/migration.py
@@ -17,11 +17,6 @@ def detect_db_files(data_dir: str, datastore_name: str = None, version=None) -> 
     return db_files
 
 
-def config_to_sqlite():
-    pass
-    # Here be config changing logic
-
-
 def check_for_migration(datastore: AbstractStorage):
     data_dir = get_data_dir("aw-server")
 
@@ -32,10 +27,6 @@ def check_for_migration(datastore: AbstractStorage):
         peewee_db_v2 = detect_db_files(data_dir, peewee_name, 2)
         if len(peewee_db_v2) > 0:
             peewee_v2_to_sqlite_v1(datastore)
-
-    if datastore.sid == "peewee":
-        config_to_sqlite()
-        logger.info("On next aw-server startup database will be migrated to sqlite.")
 
 
 def peewee_v2_to_sqlite_v1(datastore):

--- a/aw_datastore/migration.py
+++ b/aw_datastore/migration.py
@@ -1,6 +1,5 @@
 from typing import Optional, List
 import os
-import re
 import logging
 
 from aw_core.dirs import get_data_dir
@@ -18,6 +17,11 @@ def detect_db_files(data_dir: str, datastore_name: str = None, version=None) -> 
     return db_files
 
 
+def config_to_sqlite():
+    pass
+    # Here be config changing logic
+
+
 def check_for_migration(datastore: AbstractStorage):
     data_dir = get_data_dir("aw-server")
 
@@ -28,6 +32,10 @@ def check_for_migration(datastore: AbstractStorage):
         peewee_db_v2 = detect_db_files(data_dir, peewee_name, 2)
         if len(peewee_db_v2) > 0:
             peewee_v2_to_sqlite_v1(datastore)
+
+    if datastore.sid == "peewee":
+        config_to_sqlite()
+        logger.info("On next aw-server startup database will be migrated to sqlite.")
 
 
 def peewee_v2_to_sqlite_v1(datastore):


### PR DESCRIPTION
We could notify users that sqlite is the only supported backend going forward, or we could migrate config files via a script.

@ErikBjare Do you have any input on which way we should approach making existing users migrate?