### PR TITLE
test: added test for intersecting eventpairs

### DIFF
--- a/aw_transform/filter_period_intersect.py
+++ b/aw_transform/filter_period_intersect.py
@@ -25,6 +25,8 @@ def _intersecting_eventpairs(
     events1: List[Event], events2: List[Event]
 ) -> Iterable[Tuple[Event, Event, TimePeriod]]:
     """A generator that yields each overlapping pair of events from two eventlists along with a TimePeriod of the intersection"""
+    events1.sort(key=lambda e: e.timestamp)
+    events2.sort(key=lambda e: e.timestamp)
     e1_i = 0
     e2_i = 0
     while e1_i < len(events1) and e2_i < len(events2):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -107,6 +107,12 @@ def test_intersecting_eventpairs():
     intersecting = list(_intersecting_eventpairs(e1, e2))
     assert len(intersecting) == 1
 
+    # Test same as before, but reversed
+    e1 = list(reversed(e1))
+    e2 = list(reversed(e2))
+    intersecting = list(_intersecting_eventpairs(e1, e2))
+    assert len(intersecting) == 1
+
 
 def test_filter_period_intersect():
     td1h = timedelta(hours=1)


### PR DESCRIPTION
The intersection check I made in https://github.com/ActivityWatch/aw-client/pull/50 doesn't work, leading me to believe there is a bug in `_intersecting_eventpairs`.

I can't figure out what is causing it, here's what I tried to reproduce in tests.