### PR TITLE
Only filter by app & title keys by default

### DIFF
--- a/aw_transform/classify.py
+++ b/aw_transform/classify.py
@@ -15,7 +15,7 @@ class Rule:
     ignore_case: bool
 
     def __init__(self, rules: Dict[str, Any]):
-        self.select_keys = rules.get("select_keys", None)
+        self.select_keys = rules.get("select_keys", ["app", "title"])
         self.ignore_case = rules.get("ignore_case", False)
 
         # NOTE: Also checks that the regex isn't an empty string (which would erroneously match everything)
@@ -29,10 +29,15 @@ class Rule:
         )
 
     def match(self, e: Event) -> bool:
-        if self.select_keys:
-            values = [e.data.get(key, None) for key in self.select_keys]
-        else:
+        # `data` contains keys like 'app', 'title'
+        # by default, the rule regex is matched against all values
+
+        if self.select_keys == 'all'
             values = list(e.data.values())
+        elif self.select_keys:
+            values = [e.data.get(key, None) for key in self.select_keys]
+
+        # although there is a `type` field on the rule name, right now the only valid type is regex
         if self.regex:
             for val in values:
                 if isinstance(val, str) and self.regex.search(val):
@@ -45,6 +50,7 @@ def categorize(events: List[Event], classes: List[Tuple[Category, Rule]]):
 
 
 def _categorize_one(e: Event, classes: List[Tuple[Category, Rule]]) -> Event:
+    # TODO can we add a color here too? why is color rendered on the frontend?
     e.data["$category"] = _pick_category(
         [_cls for _cls, rule in classes if rule.match(e)]
     )


### PR DESCRIPTION
Matching against url, editor payload keys, etc could be problematic. The existing rules are written against these two fields, as far as I can tell.
