### PR TITLE
fix: Add flush+fsync to write of config files

### DIFF
--- a/aw_core/config.py
+++ b/aw_core/config.py
@@ -33,3 +33,6 @@ def save_config(appname, config):
     config_file_path = os.path.join(config_dir, "{}.ini".format(appname))
     with open(config_file_path, "w") as f:
         config.write(f)
+        # Flush and fsync to lower risk of corrupted files
+        f.flush()
+        os.fsync(f.fileno())


### PR DESCRIPTION
This is to lower the risk of corrupted config files

Hopefully this should reduce the risk of issues like https://github.com/ActivityWatch/activitywatch/issues/502

The writes are still not completely safe though I think, to do that you would need to temporarily write the file to another file, flush+fsync and then move the file over the old one as renaming a file is atomic. At least that's how it works on Linux, assume it's the same on macOS/Linux.
But this was a quick fix and probably good enough.