### PR TITLE
fix: add ability to set the log level via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Core library for ActivityWatch.
  - `aw_transform`, all event-transforms used in queries.
  - `aw_query`, the query-language used by ActivityWatch.
 
+## Logging
+
+Run python with `LOG_LEVEL=debug` to use change the log level across all AW components
 
 ## How to install
 

--- a/aw_core/log.py
+++ b/aw_core/log.py
@@ -32,6 +32,11 @@ def setup_logging(
     root_logger.setLevel(logging.DEBUG if verbose else logging.INFO)
     root_logger.handlers = []
 
+    # run with LOG_LEVEL=DEBUG to customize log level across all AW components
+    log_level = os.environ.get('LOG_LEVEL')
+    if log_level:
+        root_logger.setLevel(logging.__getattribute__(log_level.upper()))
+
     if log_stderr:
         root_logger.addHandler(_create_stderr_handler())
     if log_file:

--- a/aw_core/log.py
+++ b/aw_core/log.py
@@ -35,7 +35,10 @@ def setup_logging(
     # run with LOG_LEVEL=DEBUG to customize log level across all AW components
     log_level = os.environ.get('LOG_LEVEL')
     if log_level:
-        root_logger.setLevel(logging.__getattribute__(log_level.upper()))
+        if hasattr(logging, log_level.upper()):
+            root_logger.setLevel(getattr(logging, log_level.upper()))
+        else:
+            root_logger.warning(f'No logging level called {log_level} (as specified in env var)')
 
     if log_stderr:
         root_logger.addHandler(_create_stderr_handler())


### PR DESCRIPTION
As discussed in https://github.com/ActivityWatch/aw-client/pull/57/files﻿ this PR adds the ability to set the log level of all AW components via a ENV variable.
