### PR TITLE
fix: prevent `KeyError: 'title'` in `filter_keyvals_regex()`

### DIFF
--- a/aw_transform/filter_keyvals.py
+++ b/aw_transform/filter_keyvals.py
@@ -23,6 +23,6 @@ def filter_keyvals_regex(events: List[Event], key: str, regex: str) -> List[Even
     r = re.compile(regex)
 
     def predicate(event):
-        return bool(r.findall(event.data[key]))
+        return key in event.data and bool(r.findall(event.data[key]))
 
     return [e for e in events if predicate(e)]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -69,6 +69,16 @@ def test_filter_keyval_regex():
     assert len(events_re) == 2
 
 
+def test_filter_keyval_regex_keyerror():
+    events = [
+        Event(data={"label": "aa"}),
+        Event(),
+        Event(data={"label": "cc"}),
+    ]
+    events_re = filter_keyvals_regex(events, "label", "aa|cc")
+    assert len(events_re) == 2
+
+
 def test_intersecting_eventpairs():
     td1h = timedelta(hours=1)
     now = datetime.now()


### PR DESCRIPTION
Fixes https://github.com/ActivityWatch/activitywatch/issues/907

---

Based on `filter_keyvals()`, I've updated the `filter_keyvals_regex()` function.