### PR TITLE
build: fix inclusion of aw-cli command and click dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ homepage = "https://activitywatch.net/"
 repository = "https://github.com/ActivityWatch/aw-core/"
 documentation = "https://docs.activitywatch.net/"
 packages = [
+    { include = "aw_cli" },
     { include = "aw_core" },
     { include = "aw_datastore" },
     { include = "aw_transform" },
@@ -29,6 +30,7 @@ strict-rfc3339 = "^0.7"
 tomlkit = "*"
 deprecation = "*"
 timeslot = "*"
+click = "*"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "*"


### PR DESCRIPTION
The aw-cli entry point is part of the wheel, but is non-functional without the aw_cli package and the click dependency.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `aw-cli` command by including `aw_cli` package and adding `click` dependency in `pyproject.toml`.
> 
>   - **Dependencies**:
>     - Add `click` to `[tool.poetry.dependencies]` in `pyproject.toml` to ensure `aw-cli` command functionality.
>   - **Packages**:
>     - Include `aw_cli` in `[tool.poetry.packages]` in `pyproject.toml` to make the `aw-cli` entry point functional.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-core&utm_source=github&utm_medium=referral)<sup> for 0a64f19ad90c0bbf7e10a4c6d4da17107c4ac1de. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->