### PR TITLE
fix(query): handle semicolons inside string literals

### DIFF
--- a/aw_query/query2.py
+++ b/aw_query/query2.py
@@ -401,6 +401,33 @@ def get_return(namespace):
     return namespace["RETURN"]
 
 
+def _split_query_statements(query: str) -> List[str]:
+    """Split query into statements on semicolons, ignoring semicolons inside string literals."""
+    statements = []
+    current = ""
+    in_single_quote = False
+    in_double_quote = False
+    prev_char = None
+
+    for char in query:
+        if char == "'" and prev_char != "\\" and not in_double_quote:
+            in_single_quote = not in_single_quote
+            current += char
+        elif char == '"' and prev_char != "\\" and not in_single_quote:
+            in_double_quote = not in_double_quote
+            current += char
+        elif char == ";" and not in_single_quote and not in_double_quote:
+            statements.append(current)
+            current = ""
+        else:
+            current += char
+        prev_char = char
+
+    if current:
+        statements.append(current)
+    return statements
+
+
 def query(
     name: str, query: str, starttime: datetime, endtime: datetime, datastore: Datastore
 ) -> Any:
@@ -409,7 +436,7 @@ def query(
     namespace["STARTTIME"] = starttime.isoformat()
     namespace["ENDTIME"] = endtime.isoformat()
 
-    query_stmts = query.split(";")
+    query_stmts = _split_query_statements(query)
     for statement in query_stmts:
         statement = statement.strip()
         if statement:

--- a/tests/test_query2.py
+++ b/tests/test_query2.py
@@ -19,6 +19,7 @@ from aw_query.query2 import (
     QString,
     QVariable,
     _parse_token,
+    _split_query_statements,
 )
 
 from .utils import param_datastore_objects
@@ -227,6 +228,41 @@ def test_query2_return_value():
     with pytest.raises(QueryParseException):
         example_query = "a=1"
         result = query(qname, example_query, starttime, endtime, ds)
+
+
+def test_query2_semicolon_in_string():
+    """Test that semicolons inside string literals don't break query parsing (issue #145)."""
+    ds = mock_ds
+    qname = "asd"
+    starttime = iso8601.parse_date("1970-01-01")
+    endtime = iso8601.parse_date("1970-01-02")
+
+    # Semicolon in double-quoted string
+    example_query = 'RETURN = "hello;world"'
+    result = query(qname, example_query, starttime, endtime, ds)
+    assert result == "hello;world"
+
+    # Semicolon in single-quoted string
+    example_query = "RETURN = 'hello;world'"
+    result = query(qname, example_query, starttime, endtime, ds)
+    assert result == "hello;world"
+
+    # Multiple statements where one value contains a semicolon in a string
+    example_query = 'a = "foo;bar"; RETURN = a'
+    result = query(qname, example_query, starttime, endtime, ds)
+    assert result == "foo;bar"
+
+
+def test_split_query_statements():
+    """Unit test for _split_query_statements."""
+    # Basic split
+    assert _split_query_statements("a=1;b=2") == ["a=1", "b=2"]
+    # Semicolon inside double quotes should NOT split
+    assert _split_query_statements('a="x;y";b=2') == ['a="x;y"', "b=2"]
+    # Semicolon inside single quotes should NOT split
+    assert _split_query_statements("a='x;y';b=2") == ["a='x;y'", "b=2"]
+    # Trailing semicolon — empty trailing part is omitted
+    assert _split_query_statements("a=1;") == ["a=1"]
 
 
 def test_query2_multiline():


### PR DESCRIPTION
## Summary

Fixes ActivityWatch/aw-server#145.

The query parser was using `query.split(';')` to separate statements, which incorrectly split on semicolons inside string literals, causing `QueryParseException` for valid queries like:

```
RETURN = "hello;world"
```

## Root Cause

In `aw_query/query2.py`, the `query()` function did:

```python
query_stmts = query.split(";")
```

This splits on **all** semicolons, including those inside string literals. The rest of the parser correctly handles string tokenization (see `QString.check()`), but statement splitting happened before tokenization.

## Fix

Replace `query.split(";")` with a new `_split_query_statements()` function that tracks quote state (single/double) and only splits on semicolons that are actual statement terminators — not those inside string literals.

## Tests

Added:
- `test_query2_semicolon_in_string` — end-to-end query tests with semicolons in strings
- `test_split_query_statements` — unit tests for the new splitter function

All 29 existing tests continue to pass.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes query parsing to handle semicolons inside string literals by replacing `split` with a custom function in `query2.py`.
> 
>   - **Behavior**:
>     - Replaces `query.split(";")` with `_split_query_statements()` in `query()` in `query2.py` to correctly handle semicolons inside string literals.
>     - `_split_query_statements()` tracks quote state to avoid splitting within string literals.
>   - **Tests**:
>     - Adds `test_query2_semicolon_in_string` for end-to-end testing of semicolons in strings.
>     - Adds `test_split_query_statements` for unit testing the new splitting function.
>     - All 29 existing tests continue to pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-core&utm_source=github&utm_medium=referral)<sup> for 66a8d55ee364ea4e543e7f7902df631b5343026b. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->