### PR TITLE
fix(peewee): enable WAL journal mode for SQLite

### DIFF
--- a/aw_datastore/storages/peewee.py
+++ b/aw_datastore/storages/peewee.py
@@ -146,7 +146,10 @@ class PeeweeStorage(AbstractStorage):
             )
             filepath = os.path.join(data_dir, filename)
         self.db = _db
-        self.db.init(filepath)
+        self.db.init(filepath, pragmas={
+            "journal_mode": "wal",
+            "wal_autocheckpoint": 100,
+        })
         logger.info(f"Using database file: {filepath}")
         self.db.connect()
 

--- a/aw_datastore/storages/peewee.py
+++ b/aw_datastore/storages/peewee.py
@@ -148,7 +148,6 @@ class PeeweeStorage(AbstractStorage):
         self.db = _db
         self.db.init(filepath, pragmas={
             "journal_mode": "wal",
-            "wal_autocheckpoint": 100,
         })
         logger.info(f"Using database file: {filepath}")
         self.db.connect()


### PR DESCRIPTION
## Summary
- Enable WAL (Write-Ahead Logging) journal mode for PeeweeStorage's SQLite database
- `SqliteStorage` already had WAL enabled, but `PeeweeStorage` (the default backend) did not

## Problem
Without WAL mode, SQLite uses DELETE journal mode which requires exclusive locks for writes. When aw-server's threaded Flask handles concurrent heartbeats from multiple watchers, this causes frequent `sqlite3.OperationalError: database is locked` errors.

On one system, this resulted in:
- **3,984 "database is locked" errors** in a 21-day session
- **1,992 HTTP 500 responses** to watcher heartbeats
- Watchers retrying failed heartbeats, creating a cascade of load
- **2060 CPU-minutes** accumulated by the aw-server process

## Fix
WAL mode allows concurrent readers and a single writer without blocking, dramatically reducing contention. This is a one-line change to pass `pragmas={"journal_mode": "wal"}` to `SqliteExtDatabase.init()`.

## Test plan
- [ ] Existing tests pass
- [ ] Verify WAL mode is active: `sqlite3 <db-path> "PRAGMA journal_mode;"` should return `wal`
- [ ] Monitor for "database is locked" errors with multiple active watchers

Related: ActivityWatch/aw-server#151