### PR TITLE
feat: add support for optional pulsetime param to flood in query2

### DIFF
--- a/aw_query/functions.py
+++ b/aw_query/functions.py
@@ -280,8 +280,8 @@ def q2_union_no_overlap(events1: list, events2: list) -> List[Event]:
 
 @q2_function(flood)
 @q2_typecheck
-def q2_flood(events: list) -> List[Event]:
-    return flood(events)
+def q2_flood(events: list, pulsetime: float = 5) -> List[Event]:
+    return flood(events, pulsetime)
 
 
 """

--- a/tests/test_flood.py
+++ b/tests/test_flood.py
@@ -78,3 +78,24 @@ def test_flood_negative_small_gap_differing_data():
     flooded = flood(events)
     duration = sum((e.duration for e in flooded), timedelta(0))
     assert duration == timedelta(seconds=100 + 99.99)
+
+
+def test_flood_with_custom_pulsetime():
+    """Test that flood respects custom pulsetime parameter"""
+    # Create events with 30s gap (simulating 30s poll_time)
+    events = [
+        Event(timestamp=now, duration=5, data={"a": 0}),
+        Event(timestamp=now + 35 * td1s, duration=5, data={"b": 1}),
+    ]
+    
+    # With default pulsetime=5, gap should NOT be flooded
+    flooded_default = flood(events)
+    assert len(flooded_default) == 2
+    total_duration_default = sum((e.duration for e in flooded_default), timedelta(0))
+    assert total_duration_default == timedelta(seconds=10)
+    
+    # With pulsetime=31 (matching 30s poll_time + 1), gap should be flooded
+    flooded_custom = flood(events, pulsetime=31)
+    assert len(flooded_custom) == 2
+    total_duration_custom = sum((e.duration for e in flooded_custom), timedelta(0))
+    assert total_duration_custom == timedelta(seconds=40)  # Full duration with gap filled


### PR DESCRIPTION
I had this in a dirty working tree, can't remember why I added it. But kinda makes sense?