### PR TITLE
fix: use UTC-aware datetime for bucket.created default

### DIFF
--- a/aw_datastore/storages/peewee.py
+++ b/aw_datastore/storages/peewee.py
@@ -88,7 +88,7 @@ class BaseModel(Model):
 class BucketModel(BaseModel):
     key = IntegerField(primary_key=True)
     id = CharField(unique=True)
-    created = DateTimeField(default=datetime.now)
+    created = DateTimeField(default=lambda: datetime.now(timezone.utc))
     name = CharField(null=True)
     type = CharField()
     client = CharField()
@@ -112,7 +112,7 @@ class BucketModel(BaseModel):
 class EventModel(BaseModel):
     id = AutoField()
     bucket = ForeignKeyField(BucketModel, backref="events", index=True)
-    timestamp = DateTimeField(index=True, default=datetime.now)
+    timestamp = DateTimeField(index=True, default=lambda: datetime.now(timezone.utc))
     duration = DecimalField()
     datastr = CharField()
 


### PR DESCRIPTION
\`datetime.now()\` without arguments returns a naive local datetime. When peewee stores it and \`iso8601.parse_date\` later serializes it, the parser tags the bare datetime as UTC by default — so \`bucket.created\` ends up shifted by the host's TZ offset.

Switching to \`datetime.now(timezone.utc)\` produces a proper UTC-aware datetime, matching the convention that watchers already use for event timestamps.

Applied the same fix to \`EventModel.timestamp\` for consistency, though that default is rarely hit since watchers provide their own timestamps.

Fixes #134