### PR TITLE
fix: variable shadowing in log CLI, rename find_oldest_log to find_latest_log

### DIFF
--- a/aw_cli/__main__.py
+++ b/aw_cli/__main__.py
@@ -9,7 +9,7 @@ import subprocess
 
 import click
 
-from aw_cli.log import find_oldest_log, print_log, LOGLEVELS
+from aw_cli.log import find_latest_log, print_log, LOGLEVELS
 from typing import Optional
 
 
@@ -63,20 +63,20 @@ def logs(
     testing = ctx.parent.params["testing"]
     logdir: Path = Path(get_log_dir(None))
 
-    # find the oldest logfile in each of the subdirectories in the logging directory, and print the last lines in each one.
+    # find the latest logfile in each of the subdirectories in the logging directory, and print the lines in each one.
 
     if module_name:
-        print_oldest_log(logdir / module_name, testing, since, level)
+        print_latest_log(logdir / module_name, testing, since, level)
     else:
         for subdir in sorted(logdir.iterdir()):
             if subdir.is_dir():
-                print_oldest_log(subdir, testing, since, level)
+                print_latest_log(subdir, testing, since, level)
 
 
-def print_oldest_log(path, testing, since, level):
-    path = find_oldest_log(path, testing)
-    if path:
-        print_log(path, since, level)
+def print_latest_log(path, testing, since, level):
+    logfile = find_latest_log(path, testing)
+    if logfile:
+        print_log(logfile, since, level)
     else:
         print(f"No logfile found in {path}")
 

--- a/aw_cli/log.py
+++ b/aw_cli/log.py
@@ -39,7 +39,7 @@ def print_log(
     print(f"  (Filtered {lines_printed}/{len(lines)} lines)")
 
 
-def find_oldest_log(path: Path, testing=False) -> Path:
+def find_latest_log(path: Path, testing=False) -> Path:
     if not path.is_dir():
         return
 


### PR DESCRIPTION
Found two small issues in `aw_cli`:

**1. Variable shadowing bug in `print_oldest_log`**

`path` gets reassigned to the return value of `find_oldest_log()`, so when no log is found the error message prints `None` instead of the original directory:

```
# before: prints "No logfile found in None"
# after:  prints "No logfile found in /home/user/.local/share/activitywatch/log/aw-server-rust"
```

Fixed by using a separate `logfile` variable.

**2. Misleading function name**

`find_oldest_log` sorts by `st_mtime` and takes `[-1]` — that is the *newest* file, not the oldest. Renamed to `find_latest_log` to match what the code actually does.