### PR TITLE
fix(query): expose pulsetime param in q2_flood

### DIFF
--- a/aw_query/functions.py
+++ b/aw_query/functions.py
@@ -292,8 +292,8 @@ def q2_union_no_overlap(events1: list, events2: list) -> List[Event]:
 
 @q2_function(flood)
 @q2_typecheck
-def q2_flood(events: list) -> List[Event]:
-    return flood(events)
+def q2_flood(events: list, pulsetime: float = 5) -> List[Event]:
+    return flood(events, pulsetime)
 
 
 """

--- a/tests/test_query2.py
+++ b/tests/test_query2.py
@@ -612,3 +612,58 @@ def test_query2_query_categorize(datastore):
         assert result["events_by_cat"][1].duration == timedelta(seconds=2)
     finally:
         datastore.delete_bucket(bid)
+
+
+@pytest.mark.parametrize("datastore", param_datastore_objects())
+def test_query2_flood_with_pulsetime(datastore):
+    """Test that flood() accepts an optional pulsetime argument (fixes WorkReport query bug)."""
+    bid = "test_flood_bucket"
+    qname = "test_flood"
+    starttime = iso8601.parse_date("1970")
+    endtime = starttime + timedelta(hours=1)
+
+    try:
+        bucket = datastore.create_bucket(
+            bucket_id=bid,
+            type="test",
+            client="test",
+            hostname="test",
+            name="flood_test",
+        )
+        # Two events with a 60-second gap — flood with pulsetime=300 should merge them
+        bucket.insert(
+            Event(
+                data={"app": "Firefox"},
+                timestamp=starttime,
+                duration=timedelta(seconds=10),
+            )
+        )
+        bucket.insert(
+            Event(
+                data={"app": "Firefox"},
+                timestamp=starttime + timedelta(seconds=70),
+                duration=timedelta(seconds=10),
+            )
+        )
+
+        # flood with default pulsetime (5s) — gap is 60s, events should NOT merge
+        result_default = query(
+            qname,
+            f'events = query_bucket("{bid}"); events = flood(events); RETURN = events;',
+            starttime,
+            endtime,
+            datastore,
+        )
+        assert len(result_default) == 2
+
+        # flood with pulsetime=300 — gap is 60s < 300s, events SHOULD merge
+        result_pulsetime = query(
+            qname,
+            f'events = query_bucket("{bid}"); events = flood(events, 300); RETURN = events;',
+            starttime,
+            endtime,
+            datastore,
+        )
+        assert len(result_pulsetime) == 1
+    finally:
+        datastore.delete_bucket(bid)


### PR DESCRIPTION
## Problem

The Work Time Report in aw-webui generates queries like:

```
events_0 = flood(query_bucket("aw-watcher-window_Host"), 300);
```

where `300` is the user-configured break time in seconds. The query language wrapper `q2_flood` only accepted one argument, causing:

```json
{"type": "QueryInterpreterException", "message": "Tried to call function flood with invalid amount of arguments"}
```

This breaks the Work Time Report completely (ActivityWatch/activitywatch#1361).

## Fix

The underlying `flood()` transform in `aw_transform/flood.py` already accepts `pulsetime: float = 5` as an optional parameter. This PR exposes it in the query language:

```python
# Before
def q2_flood(events: list) -> List[Event]:
    return flood(events)

# After
def q2_flood(events: list, pulsetime: float = 5) -> List[Event]:
    return flood(events, pulsetime)
```

The default is unchanged (5 seconds), so all existing single-argument `flood()` calls are unaffected.

## Test

Added `test_query2_flood_with_pulsetime` which verifies:
- `flood(events)` with the default 5s pulsetime leaves a 60s gap unfilled (2 events remain)
- `flood(events, 300)` with a 300s pulsetime fills the 60s gap (1 merged event)

Fixes ActivityWatch/activitywatch#1361