### PR TITLE
fix(transform): normalize flood() output to remove overlapping events

### DIFF
--- a/aw_transform/flood.py
+++ b/aw_transform/flood.py
@@ -80,7 +80,33 @@ def flood(events: List[Event], pulsetime: float = 5) -> List[Event]:
                     e2.timestamp = e1.timestamp + e1.duration
                     e2.duration = e2_end - e2.timestamp
 
-    # Filter out remaining zero-duration events
-    events = [e for e in events if e.duration > timedelta(0)]
+    # Pairwise flooding can mutate an event after its previous pair has already
+    # been processed. Normalize the final stream so downstream consumers never
+    # double-count overlapping time. For differing data, the later event wins.
+    normalized: List[Event] = []
+    for event in (e for e in events if e.duration > timedelta(0)):
+        while (
+            normalized
+            and normalized[-1].timestamp + normalized[-1].duration > event.timestamp
+        ):
+            previous = normalized[-1]
 
-    return events
+            if previous.data == event.data:
+                end = max(
+                    previous.timestamp + previous.duration,
+                    event.timestamp + event.duration,
+                )
+                previous.duration = end - previous.timestamp
+                break
+
+            previous.duration = event.timestamp - previous.timestamp
+            if previous.duration <= timedelta(0):
+                normalized.pop()
+                continue
+
+            normalized.append(event)
+            break
+        else:
+            normalized.append(event)
+
+    return normalized

--- a/tests/test_flood.py
+++ b/tests/test_flood.py
@@ -67,7 +67,51 @@ def test_flood_negative_gap_differing_data():
         Event(timestamp=now, duration=100, data={"b": 1}),
     ]
     flooded = flood(events)
-    assert flooded == events
+    assert flooded == [events[1]]
+
+
+def test_flood_zero_duration_chain_does_not_leave_overlaps():
+    events = [
+        Event(timestamp=now, duration=0, data={"title": "first"}),
+        Event(timestamp=now, duration=1, data={"title": "first"}),
+        Event(timestamp=now, duration=1, data={"title": "second"}),
+    ]
+
+    flooded = flood(events)
+
+    assert flooded == [events[2]]
+    assert all(
+        previous.timestamp + previous.duration <= current.timestamp
+        for previous, current in zip(flooded, flooded[1:])
+    )
+
+
+def test_flood_normalization_preserves_non_overlapping_tail():
+    events = [
+        Event(timestamp=now, duration=10, data={"title": "first"}),
+        Event(timestamp=now + 5 * td1s, duration=2, data={"title": "second"}),
+        Event(timestamp=now + 12 * td1s, duration=1, data={"title": "third"}),
+    ]
+
+    flooded = flood(events)
+
+    assert flooded == [
+        Event(timestamp=now, duration=5, data={"title": "first"}),
+        Event(timestamp=now + 5 * td1s, duration=7, data={"title": "second"}),
+        events[2],
+    ]
+
+
+def test_flood_normalization_merges_same_data_after_zero_duration_event():
+    events = [
+        Event(timestamp=now, duration=0, data={"title": "zero"}),
+        Event(timestamp=now, duration=10, data={"title": "same"}),
+        Event(timestamp=now + 5 * td1s, duration=10, data={"title": "same"}),
+    ]
+
+    flooded = flood(events)
+
+    assert flooded == [Event(timestamp=now, duration=15, data={"title": "same"})]
 
 
 def test_flood_negative_small_gap_differing_data():


### PR DESCRIPTION
## Problem

`flood()` can return overlapping positive-duration events when the pairwise
flooding loop mutates events that have already been processed. Downstream
duration aggregation counts each event independently, so overlapping events
cause hourly totals to exceed wall-clock time — reported as 60–71 minute hours
in the ActivityWatch Summary timeline.

Minimal reproducer from ActivityWatch/activitywatch#1369:

```python
events = [
    Event(timestamp=start, duration=0, data={"title": "first"}),
    Event(timestamp=start, duration=1, data={"title": "first"}),
    Event(timestamp=start, duration=1, data={"title": "second"}),
]
result = flood(events)
# result contains two 1-second events at the same timestamp → 2s counted in 1s of wall-clock
```

The root cause: when `gap < -negative_gap_trim_thres` and the two events have
different data, the existing code only logs a warning and leaves both events
unchanged. Because the pairwise loop has already advanced past the earlier pair,
those overlaps survive the final zero-duration filter.

## Fix

Replace the final zero-duration filter with a normalization pass that guarantees
a non-overlapping stream at the output boundary:

- **Same-data overlap**: merge into one event (union of both durations).
- **Different-data overlap**: later event wins; clip the earlier event to end at
  the later event's start. Drop the earlier event if clipping reduces it to zero
  duration.

This is the same policy the reporter's local fix used and is consistent with the
earlier-event-trimming direction in #105.

The normalization pass is a purely additive safety net — it does not change the
pairwise flooding logic, so existing behaviour for non-overlapping inputs is
preserved.

## Tests

- Updated `test_flood_negative_gap_differing_data` to assert the new (correct)
  behaviour: the earlier event is clipped away, leaving only the later event.
- Added `test_flood_zero_duration_chain_does_not_leave_overlaps` (the exact
  reproducer from the bug report).
- Added `test_flood_normalization_preserves_non_overlapping_tail` — ensures the
  pass does not disturb events that follow the overlap.
- Added `test_flood_normalization_merges_same_data_after_zero_duration_event` —
  covers the equal-data merge path.

All 174 tests pass; Ruff clean; targeted mypy clean.

## Related

- ActivityWatch/activitywatch#1369 — bug report with minimal reproducer
- #105 — earlier proposal to trim the smaller event on unsafe negative gaps
- #73 — earlier flooding algorithm changes