### PR TITLE
fix(transform): sort by (timestamp, duration) and add flood idempotency tests

### DIFF
--- a/aw_transform/flood.py
+++ b/aw_transform/flood.py
@@ -21,7 +21,10 @@ def flood(events: List[Event], pulsetime: float = 5) -> List[Event]:
     #        - https://github.com/ActivityWatch/aw-core/pull/73
 
     events = deepcopy(events)
-    events = sorted(events, key=lambda e: e.timestamp)
+    # Sort by (timestamp, duration) so shorter same-timestamp events come first.
+    # This matches aw-server-rust's sort_by_timestamp behavior and ensures
+    # a well-defined processing order when events share the same timestamp.
+    events = sorted(events, key=lambda e: (e.timestamp, e.duration))
 
     # If negative gaps are smaller than this, prune them to become zero
     negative_gap_trim_thres = timedelta(seconds=0.1)

--- a/tests/test_flood.py
+++ b/tests/test_flood.py
@@ -142,3 +142,33 @@ def test_flood_with_custom_pulsetime():
     assert len(flooded_custom) == 2
     total_duration_custom = sum((e.duration for e in flooded_custom), timedelta(0))
     assert total_duration_custom == timedelta(seconds=40)
+
+
+def test_flood_idempotent():
+    """flood() applied repeatedly should produce the same result."""
+    events = [
+        # slight overlap, same data
+        Event(timestamp=now, duration=10, data={"a": 0}),
+        Event(timestamp=now + 9 * td1s, duration=5, data={"a": 0}),
+        # different data, no overlap
+        Event(timestamp=now + 15 * td1s, duration=5, data={"b": 0}),
+    ]
+    flood_first = flood(events, pulsetime=0)
+    flooded = flood_first
+    for _ in range(2):
+        flooded = flood(flooded, pulsetime=0)
+        assert flood_first == flooded
+
+    assert sum((e.duration for e in flooded), timedelta(0)) == 19 * td1s
+
+
+def test_flood_unsafe_gap():
+    """Overlapping events with differing data must not double-count time."""
+    events = [
+        Event(timestamp=now, duration=10, data={"a": 0}),
+        Event(timestamp=now + 9 * td1s, duration=5, data={"b": 0}),
+    ]
+    flooded = flood(events, pulsetime=0)
+
+    # Total duration must not exceed the span covered by the two events
+    assert sum((e.duration for e in flooded), timedelta(0)) == 14 * td1s


### PR DESCRIPTION
Ports two remaining improvements from #105 that weren't included in #143.

## Changes

### 1. Sort key: `(timestamp, duration)` instead of just `timestamp`

When multiple events share the same timestamp, shorter events now sort first. This gives a deterministic processing order for same-timestamp inputs and aligns with aw-server-rust's behavior (its `sort_by_timestamp` processes shorter events first when timestamps are equal).

### 2. Two new tests

- **`test_flood_idempotent`**: verifies that calling `flood()` repeatedly on its own output returns the same result — an important correctness property. Adapted from #105.
- **`test_flood_unsafe_gap`**: verifies that overlapping events with differing data don't double-count time (validates the normalization pass added in #143). Adapted from #105.

Both tests pass on the current master (no other code changes needed).

## aw-server-rust spec comparison

Per Erik's request, I compared the Python implementation against aw-server-rust's [flood.rs](https://github.com/ActivityWatch/aw-server-rust/blob/master/aw-transform/src/flood.rs). The sort key change above aligns them. One notable remaining divergence:

**Positive gap, differing data**: aw-server-rust does **"meet in the middle"** — each event extends by `gap/2`. The Python implementation does **"longer wins"** — the longer event fills the entire gap. The normalization pass from #143 means both implementations produce overlap-free output, but the gap-split point differs. Leaving this for a separate discussion since it's a more significant behaviour change.