### PR TITLE
fix(transform): split uncertain flood gaps at midpoint

### DIFF
--- a/aw_transform/flood.py
+++ b/aw_transform/flood.py
@@ -9,11 +9,20 @@ logger = logging.getLogger(__name__)
 
 
 def flood(events: List[Event], pulsetime: float = 5) -> List[Event]:
-    """
-    Takes a list of events and "floods" any empty space between events by extending one of the surrounding events to cover the empty space.
+    """Fill short gaps between events and merge nearby equal-data events.
 
-    For more details on flooding, see this issue:
-     - https://github.com/ActivityWatch/activitywatch/issues/124
+    Events are ordered by timestamp and duration. Gaps no larger than
+    ``pulsetime`` are filled. Equal-data neighbours merge across the gap; when
+    their data differs, both events extend to the midpoint. Splitting an
+    uncertain interval evenly is independent of the surrounding event lengths
+    and matches the Rust implementation.
+
+    Overlapping equal-data events merge. For overlapping differing-data events,
+    final normalization gives the later event precedence so the result never
+    double-counts time.
+
+    See https://github.com/ActivityWatch/activitywatch/issues/124 for the data
+    collection uncertainty that flooding is intended to handle.
     """
     # Originally written in aw-research: https://github.com/ActivityWatch/aw-analysis/blob/7da1f2cd8552f866f643501de633d74cdecab168/aw_analysis/flood.py
     # NOTE: This algorithm has a lot of smaller details that need to be
@@ -61,27 +70,24 @@ def flood(events: List[Event], pulsetime: float = 5) -> List[Event]:
         elif -negative_gap_trim_thres < gap <= timedelta(seconds=pulsetime):
             e2_end = e2.timestamp + e2.duration
 
-            # Prioritize flooding from the longer event
-            if e1.duration >= e2.duration:
-                if e1.data == e2.data:
-                    # Extend e1 to the end of e2
-                    # Set duration of e2 to zero (mark to delete)
+            if e1.data == e2.data:
+                # Preserve the longer neighbour's extent while merging across
+                # the gap, matching the existing semantics for equal data.
+                if e1.duration >= e2.duration:
                     e1.duration = e2_end - e1.timestamp
                     e2.timestamp = e2_end
                     e2.duration = timedelta(0)
                 else:
-                    # Extend e1 to the start of e2
-                    e1.duration = e2.timestamp - e1.timestamp
-            else:
-                if e1.data == e2.data:
-                    # Extend e2 to the start of e1, discard e1
                     e2.timestamp = e1.timestamp
                     e2.duration = e2_end - e2.timestamp
                     e1.duration = timedelta(0)
-                else:
-                    # Extend e2 backwards to end of e1
-                    e2.timestamp = e1.timestamp + e1.duration
-                    e2.duration = e2_end - e2.timestamp
+            else:
+                # The gap is an interval of uncertainty: without evidence that
+                # either neighbour owns more of it, split it at the midpoint.
+                midpoint = e1.timestamp + e1.duration + gap / 2
+                e1.duration = midpoint - e1.timestamp
+                e2.timestamp = midpoint
+                e2.duration = e2_end - midpoint
 
     # Pairwise flooding can mutate an event after its previous pair has already
     # been processed. Normalize the final stream so downstream consumers never

--- a/tests/test_flood.py
+++ b/tests/test_flood.py
@@ -8,15 +8,18 @@ now = datetime.now(tz=timezone.utc)
 td1s = timedelta(seconds=1)
 
 
-def test_flood_forward():
+def test_flood_differing_data_meet_at_gap_midpoint():
     events = [
         Event(timestamp=now, duration=10, data={"a": 0}),
-        Event(timestamp=now + 15 * td1s, duration=5, data={"b": 1}),
+        Event(timestamp=now + 14 * td1s, duration=5, data={"b": 1}),
     ]
+
     flooded = flood(events)
-    assert (flooded[0].timestamp + flooded[0].duration) - flooded[
-        1
-    ].timestamp == timedelta(0)
+
+    assert flooded == [
+        Event(timestamp=now, duration=12, data={"a": 0}),
+        Event(timestamp=now + 12 * td1s, duration=7, data={"b": 1}),
+    ]
 
 
 def test_flood_forward_merge():
@@ -27,17 +30,6 @@ def test_flood_forward_merge():
     flooded = flood(events)
     assert len(flooded) == 1
     assert flooded[0].duration == timedelta(seconds=20)
-
-
-def test_flood_backward():
-    events = [
-        Event(timestamp=now, duration=5, data={"a": 0}),
-        Event(timestamp=now + 10 * td1s, duration=10, data={"b": 1}),
-    ]
-    flooded = flood(events)
-    assert (flooded[0].timestamp + flooded[0].duration) - flooded[
-        1
-    ].timestamp == timedelta(0)
 
 
 def test_flood_backward_merge():
@@ -97,8 +89,8 @@ def test_flood_normalization_preserves_non_overlapping_tail():
 
     assert flooded == [
         Event(timestamp=now, duration=5, data={"title": "first"}),
-        Event(timestamp=now + 5 * td1s, duration=7, data={"title": "second"}),
-        events[2],
+        Event(timestamp=now + 5 * td1s, duration=4.5, data={"title": "second"}),
+        Event(timestamp=now + 9.5 * td1s, duration=3.5, data={"title": "third"}),
     ]
 
 
@@ -137,11 +129,12 @@ def test_flood_with_custom_pulsetime():
     total_duration_default = sum((e.duration for e in flooded_default), timedelta(0))
     assert total_duration_default == timedelta(seconds=10)
 
-    # pulsetime=31: gap (30s) <= pulsetime, so event 1 extends to meet event 2
+    # pulsetime=31: gap (30s) <= pulsetime, so both events extend to midpoint
     flooded_custom = flood(events, pulsetime=31)
-    assert len(flooded_custom) == 2
-    total_duration_custom = sum((e.duration for e in flooded_custom), timedelta(0))
-    assert total_duration_custom == timedelta(seconds=40)
+    assert flooded_custom == [
+        Event(timestamp=now, duration=20, data={"a": 0}),
+        Event(timestamp=now + 20 * td1s, duration=20, data={"b": 1}),
+    ]
 
 
 def test_flood_idempotent():


### PR DESCRIPTION
## Problem

Python and Rust assign short gaps between differing-data events differently:

- Python gave the entire gap to whichever surrounding event was longer.
- Rust splits the gap at its midpoint.

That makes the same stored events produce different timelines depending on the server implementation. Neither side has evidence about the actual transition point; the gap exists precisely because collection did not observe it.

## Decision: meet in the middle

Both rules are defensible:

- **Longer wins** can be read as a local confidence heuristic: a longer observed run may be more likely to continue through the gap. It also minimizes changes to the shorter event.
- **Midpoint** is neutral: it does not infer confidence from event length, is symmetric under swapping the neighbouring event durations, and keeps output consistent across Python and Rust.

I chose **midpoint**. Event duration is not a confidence measure; for heartbeat-derived events it often reflects batching or earlier transforms. Letting it decide an unobserved transition adds an unsupported bias and can move the boundary dramatically when one event happens to be long. Midpoint states the weaker, more honest assumption and already has an explicit Rust regression test.

## Changes

- Split positive gaps between differing-data events at the midpoint in Python.
- Add an exact-boundary regression with unequal event lengths, so this cannot accidentally degrade into a mere no-gap assertion.
- Update the custom-pulsetime regression and affected three-event normalization expectation.
- Expand `flood()`'s API documentation into the intended behavior/spec: ordering, pulsetime boundary, same-data merging, differing-data midpoint, and overlap precedence.

The equal-data behavior remains unchanged: neighbouring equal-data events merge, preserving the longer event's extent.

## Verification

- `poetry run pytest -q` — 176 passed, 2 skipped
- `poetry run ruff check .` — clean
- `poetry run mypy aw_transform/flood.py` — clean

Follow-up to #105; incorporates the implementation parity requested in https://github.com/ActivityWatch/aw-core/pull/105#issuecomment-5051360733.
