### PR TITLE
perf(datastore): replace single-column event indexes with composite (bucket_id, timestamp) index

### DIFF
--- a/aw_datastore/storages/peewee.py
+++ b/aw_datastore/storages/peewee.py
@@ -13,6 +13,7 @@ import iso8601
 from aw_core.dirs import get_data_dir
 from aw_core.models import Event
 from playhouse.migrate import SqliteMigrator, migrate
+
 try:
     from playhouse.sqlite_ext import SqliteExtDatabase
 except ImportError:
@@ -60,6 +61,29 @@ def auto_migrate(path: str) -> None:
         datastr_field = CharField(default="{}")
         with db.atomic():
             migrate(migrator.add_column("bucketmodel", "datastr", datastr_field))
+
+    # Replace the single-column event indexes with a composite index.
+    # Every event query filters on bucket_id and orders by timestamp (or
+    # narrows to a timestamp range), so the composite index serves the seek,
+    # the range and the ORDER BY in one pass. With only single-column indexes
+    # SQLite reads all of a bucket's rows and sorts them in a temp B-tree,
+    # even for the LIMIT 1 last-event query issued on every heartbeat merge.
+    # Dropping the old indexes also makes inserts cheaper.
+    indexes = {row[1] for row in db.execute_sql("PRAGMA index_list(eventmodel)")}
+    if "eventmodel_bucket_id_timestamp" not in indexes:
+        logger.info(
+            "Migrating event indexes, this can take a few minutes on large databases..."
+        )
+        # Drops run before the create so the pages they free are reused to
+        # build the new index within the same transaction; creating first
+        # would permanently grow the database file by the new index's size.
+        with db.atomic():
+            db.execute_sql("DROP INDEX IF EXISTS eventmodel_bucket_id")
+            db.execute_sql("DROP INDEX IF EXISTS eventmodel_timestamp")
+            db.execute_sql(
+                "CREATE INDEX eventmodel_bucket_id_timestamp"
+                " ON eventmodel (bucket_id, timestamp)"
+            )
 
     db.close()
 
@@ -110,9 +134,12 @@ class BucketModel(BaseModel):
 
 
 class EventModel(BaseModel):
+    # Events are covered by the composite (bucket_id, timestamp) index created
+    # in auto_migrate(); it is kept out of the model so create_table doesn't
+    # build it before auto_migrate has dropped the old single-column indexes.
     id = AutoField()
-    bucket = ForeignKeyField(BucketModel, backref="events", index=True)
-    timestamp = DateTimeField(index=True, default=lambda: datetime.now(timezone.utc))
+    bucket = ForeignKeyField(BucketModel, backref="events", index=False)
+    timestamp = DateTimeField(default=lambda: datetime.now(timezone.utc))
     duration = DecimalField()
     datastr = CharField()
 
@@ -150,9 +177,12 @@ class PeeweeStorage(AbstractStorage):
             )
             filepath = os.path.join(data_dir, filename)
         self.db = _db
-        self.db.init(filepath, pragmas={
-            "journal_mode": "wal",
-        })
+        self.db.init(
+            filepath,
+            pragmas={
+                "journal_mode": "wal",
+            },
+        )
         logger.info(f"Using database file: {filepath}")
         self.db.connect()
 

--- a/tests/test_peewee.py
+++ b/tests/test_peewee.py
@@ -1,0 +1,66 @@
+"""
+Peewee-storage-specific tests, mainly for the schema/index migration in
+auto_migrate() and for guarding against query-plan regressions.
+"""
+
+import logging
+
+from aw_datastore.storages import PeeweeStorage
+from aw_datastore.storages import peewee as peewee_storage
+
+from . import context  # noqa: F401
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def _indexes(db) -> set:
+    return {row[1] for row in db.execute_sql("PRAGMA index_list(eventmodel)")}
+
+
+def test_index_migration():
+    """auto_migrate() replaces the old single-column indexes with the composite one."""
+    storage = PeeweeStorage(testing=True)
+    db = storage.db
+    path = db.database
+
+    assert "eventmodel_bucket_id_timestamp" in _indexes(db)
+
+    # Recreate the pre-migration state: single-column indexes, no composite
+    db.execute_sql("DROP INDEX eventmodel_bucket_id_timestamp")
+    db.execute_sql("CREATE INDEX eventmodel_bucket_id ON eventmodel (bucket_id)")
+    db.execute_sql("CREATE INDEX eventmodel_timestamp ON eventmodel (timestamp)")
+
+    peewee_storage.auto_migrate(path)
+
+    indexes = _indexes(db)
+    assert "eventmodel_bucket_id_timestamp" in indexes
+    assert "eventmodel_bucket_id" not in indexes
+    assert "eventmodel_timestamp" not in indexes
+
+
+def test_query_plan_uses_composite_index():
+    """
+    The last-event query (issued by replace_last on every merged heartbeat) and
+    range queries must be served by the composite index in a single pass.
+
+    Without it, SQLite reads *all* of a bucket's rows and sorts them in a temp
+    B-tree even for LIMIT 1, which on multi-million-event buckets meant seconds
+    of CPU/IO per heartbeat (and terabytes read per day).
+    """
+    storage = PeeweeStorage(testing=True)
+    db = storage.db
+
+    queries = [
+        # replace_last/_get_last
+        "SELECT * FROM eventmodel WHERE bucket_id = 1"
+        " ORDER BY timestamp DESC LIMIT 1",
+        # get_events with a time range
+        "SELECT * FROM eventmodel WHERE bucket_id = 1"
+        " AND timestamp >= '2026-01-01' AND timestamp <= '2026-01-02'"
+        " ORDER BY timestamp DESC LIMIT 100",
+    ]
+    for query in queries:
+        rows = db.execute_sql(f"EXPLAIN QUERY PLAN {query}").fetchall()
+        plan = "\n".join(str(row) for row in rows)
+        assert "eventmodel_bucket_id_timestamp" in plan, plan
+        assert "TEMP B-TREE" not in plan, plan


### PR DESCRIPTION
## Problem

`aw-server` (python) was found pinned at ~60% CPU with **terabytes of disk reads per day** (38 TB over ~30 days on the machine where this was diagnosed), and the log full of `Heartbeat lock could not be acquired within timeout` 503s, causing dropped heartbeats and fragmented events.

Root cause: the peewee storage only has single-column indexes on `eventmodel` (`bucket_id`, `timestamp`). Every event query filters on `bucket_id` and orders by `timestamp`, for which SQLite picks:

```
SEARCH eventmodel USING INDEX eventmodel_bucket_id (bucket_id=?)
USE TEMP B-TREE FOR ORDER BY
```

i.e. it reads **all** of a bucket's rows and sorts them in a temp B-tree — even for the `LIMIT 1` last-event query that `replace_last()` issues on **every merged heartbeat**. On a 1.65M-row bucket that's a multi-second full-bucket scan per heartbeat, back to back, forever. (The WAL change in v0.14.0b1 fixed write amplification; this read-side pathology is independent of it, and grows linearly with bucket size.)

## Fix

Replace the single-column indexes with a composite `(bucket_id, timestamp)` index, which serves the seek, the range and the ORDER BY in one pass. This mirrors aw-server-rust's v5 migration ([`events_bucketrow_starttime_endtime_index`](https://github.com/ActivityWatch/aw-server-rust/blob/master/aw-datastore/src/datastore.rs)), including dropping the old indexes before creating the new one in the same transaction so freed pages are reused (no file growth) and inserts get cheaper (2 indexes → 1).

- New databases: model no longer declares the single-column indexes; `auto_migrate()` creates the composite.
- Existing databases: `auto_migrate()` detects the missing composite index, drops the old ones, and builds it (logged, since it takes a while on large DBs).

## Measured (real 1.45 GB DB, 6.7M events, largest bucket 1.65M rows)

| query | before | after |
|---|---|---|
| last-event (`replace_last`, per merged heartbeat) | 5.06 s | 0.028 s |
| 1-day range (`get_events`) | 4.16 s | 0.037 s |
| one-time migration | — | ~54 s, no file growth |

This also eliminates the heartbeat-lock 503s, since the lock was being held across those multi-second scans.

## Tests

- `test_index_migration`: fresh DBs get the composite index; simulated pre-migration DBs (old single-column indexes) are migrated.
- `test_query_plan_uses_composite_index`: **query-plan regression guard** — asserts the hot queries are served by the composite index and never fall back to `USE TEMP B-TREE FOR ORDER BY`. Deterministic (no timing flakiness), catches this class of regression in CI.

Note: cross-bucket queries filtering on `timestamp` alone would no longer have an index, but nothing in aw-core issues such queries (all event queries are bucket-scoped) — same trade-off aw-server-rust made.

Intended for inclusion in v0.14.0b3 (needs an aw-core release + bump in aw-server).