### PR TITLE
fix(classify): do not crash on invalid user-supplied regex

### DIFF
--- a/aw_transform/classify.py
+++ b/aw_transform/classify.py
@@ -1,9 +1,12 @@
+import logging
 from typing import Pattern, List, Iterable, Tuple, Dict, Optional, Any
 from functools import reduce
 import re
 
 from aw_core import Event
 
+
+logger = logging.getLogger(__name__)
 
 Tag = str
 Category = List[str]
@@ -20,13 +23,24 @@ class Rule:
 
         # NOTE: Also checks that the regex isn't an empty string (which would erroneously match everything)
         regex_str = rules.get("regex", None)
-        self.regex = (
-            re.compile(
-                regex_str, (re.IGNORECASE if self.ignore_case else 0) | re.UNICODE
-            )
-            if regex_str
-            else None
-        )
+        if regex_str:
+            try:
+                self.regex = re.compile(
+                    regex_str,
+                    (re.IGNORECASE if self.ignore_case else 0) | re.UNICODE,
+                )
+            except re.error as e:
+                # An invalid user-supplied pattern should not crash categorization
+                # for the entire query. Log it and disable this rule (match nothing).
+                logger.warning(
+                    "Invalid regex pattern %r in category/tag rule (%s); "
+                    "this rule will match nothing.",
+                    regex_str,
+                    e,
+                )
+                self.regex = None
+        else:
+            self.regex = None
 
     def match(self, e: Event) -> bool:
         if self.select_keys:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -435,6 +435,35 @@ def test_tags():
     assert len(events[1].data["$tags"]) == 0
 
 
+def test_rule_invalid_regex_does_not_raise():
+    # An invalid user-supplied pattern (e.g. "Notepad++" on Python versions
+    # where "++" is not a valid quantifier) must not raise from Rule.__init__.
+    # Instead the rule should silently disable itself. See:
+    # https://github.com/ActivityWatch/activitywatch/issues/1340
+    rule = Rule({"regex": "*invalid("})
+    assert rule.regex is None
+
+    now = datetime.now(timezone.utc)
+    e = Event(timestamp=now, duration=0, data={"key": "anything"})
+    assert rule.match(e) is False
+
+
+def test_categorize_survives_invalid_regex():
+    # A single bad rule should not break categorization for the rest.
+    now = datetime.now(timezone.utc)
+    classes = [
+        (["Bad"], Rule({"regex": "*invalid("})),
+        (["Test"], Rule({"regex": "^just"})),
+    ]
+    events = [
+        Event(timestamp=now, duration=0, data={"key": "just a test"}),
+        Event(timestamp=now, duration=0, data={"key": "unrelated"}),
+    ]
+    events = categorize(events, classes)
+    assert events[0].data["$category"] == ["Test"]
+    assert events[1].data["$category"] == ["Uncategorized"]
+
+
 def test_union_no_overlap():
     from pprint import pprint
 


### PR DESCRIPTION
Small drive-by fix for activitywatch/activitywatch#1340.

## What happened

`Rule.__init__` (in `aw_transform/classify.py`) compiles user-supplied
regex patterns eagerly with `re.compile(...)`. If the pattern is
invalid, `re.error` is raised straight out of `__init__`, bubbles up
through the query engine, and `aw-server` responds with **500 Internal
Server Error** for the whole query. The web UI then shows nothing for
*any* categorize()/tag() chart, not just the rule that was broken.

The reproducer in the issue is `Notepad++` (the user probably wanted
`Notepad\+\+`). On Python <= 3.10 this raises `re.error: multiple
repeat at position 8`. On 3.11+ `++` happens to be a valid possessive
quantifier so that particular pattern no longer breaks, but the class
of bug still exists: any user typo like `*foo` or `(unclosed` will
take down the whole categorize query.

## Fix

Catch `re.error` in `Rule.__init__`, log a warning, and set `self.regex
= None` so that rule matches nothing. Other rules keep working;
events that would have matched the broken rule fall through to
`Uncategorized` instead of tanking the query. The webui can still
provide inline validation on top of this later, but the server should
not 500 on user input.

## Tests

Added two tests in `tests/test_transforms.py`:

- `test_rule_invalid_regex_does_not_raise` — invalid pattern gives
  `regex=None`, `match(event)` returns `False`.
- `test_categorize_survives_invalid_regex` — a bad rule mixed with a
  good rule: good rule still categorizes, unrelated events go to
  `Uncategorized` (instead of the whole call raising).

Existing `test_categorize` / `test_tags` unchanged and still pass.

Fixes activitywatch/activitywatch#1340
