### PR TITLE
perf(aw-transform): cache categorize/tag results per event data to fix month-view timeout

### DIFF
--- a/aw_transform/classify.py
+++ b/aw_transform/classify.py
@@ -1,3 +1,4 @@
+import json
 from typing import Pattern, List, Iterable, Tuple, Dict, Optional, Any
 from functools import reduce
 import re
@@ -43,7 +44,15 @@ class Rule:
 def categorize(
     events: List[Event], classes: List[Tuple[Category, Rule]]
 ) -> List[Event]:
-    return [_categorize_one(e, classes) for e in events]
+    cache: Dict[str, Category] = {}
+    for e in events:
+        key = json.dumps(e.data, sort_keys=True)
+        if key not in cache:
+            cache[key] = _pick_category(
+                [_cls for _cls, rule in classes if rule.match(e)]
+            )
+        e.data["$category"] = list(cache[key])
+    return events
 
 
 def _categorize_one(e: Event, classes: List[Tuple[Category, Rule]]) -> Event:
@@ -54,7 +63,13 @@ def _categorize_one(e: Event, classes: List[Tuple[Category, Rule]]) -> Event:
 
 
 def tag(events: List[Event], classes: List[Tuple[Tag, Rule]]) -> List[Event]:
-    return [_tag_one(e, classes) for e in events]
+    cache: Dict[str, List[Tag]] = {}
+    for e in events:
+        key = json.dumps(e.data, sort_keys=True)
+        if key not in cache:
+            cache[key] = [_cls for _cls, rule in classes if rule.match(e)]
+        e.data["$tags"] = list(cache[key])
+    return events
 
 
 def _tag_one(e: Event, classes: List[Tuple[Tag, Rule]]) -> Event:

--- a/aw_transform/classify.py
+++ b/aw_transform/classify.py
@@ -46,7 +46,10 @@ def categorize(
 ) -> List[Event]:
     cache: Dict[str, Category] = {}
     for e in events:
-        key = json.dumps(e.data, sort_keys=True)
+        try:
+            key = json.dumps(e.data, sort_keys=True)
+        except TypeError:
+            key = str(id(e.data))
         if key not in cache:
             cache[key] = _pick_category(
                 [_cls for _cls, rule in classes if rule.match(e)]
@@ -65,7 +68,10 @@ def _categorize_one(e: Event, classes: List[Tuple[Category, Rule]]) -> Event:
 def tag(events: List[Event], classes: List[Tuple[Tag, Rule]]) -> List[Event]:
     cache: Dict[str, List[Tag]] = {}
     for e in events:
-        key = json.dumps(e.data, sort_keys=True)
+        try:
+            key = json.dumps(e.data, sort_keys=True)
+        except TypeError:
+            key = str(id(e.data))
         if key not in cache:
             cache[key] = [_cls for _cls, rule in classes if rule.match(e)]
         e.data["$tags"] = list(cache[key])

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -418,6 +418,36 @@ def test_categorize():
     assert events[3].data["$category"] == ["Uncategorized"]
 
 
+def test_categorize_cache_correctness():
+    """Cache reuses category for identical data; distinct data gets its own category."""
+    now = datetime.now(timezone.utc)
+
+    classes = [
+        (["Browser"], Rule({"regex": "Firefox"})),
+        (["Editor"], Rule({"regex": "vim"})),
+    ]
+    firefox_data = {"app": "Firefox", "title": "Home"}
+    vim_data = {"app": "vim", "title": "classify.py"}
+
+    # 50 Firefox events, 1 vim event, 50 more Firefox events
+    events = (
+        [Event(timestamp=now, duration=0, data=dict(firefox_data)) for _ in range(50)]
+        + [Event(timestamp=now, duration=0, data=dict(vim_data))]
+        + [Event(timestamp=now, duration=0, data=dict(firefox_data)) for _ in range(50)]
+    )
+    result = categorize(events, classes)
+
+    for e in result[:50]:
+        assert e.data["$category"] == ["Browser"]
+    assert result[50].data["$category"] == ["Editor"]
+    for e in result[51:]:
+        assert e.data["$category"] == ["Browser"]
+
+    # Mutating one event's category must not affect others sharing the same data fingerprint
+    result[0].data["$category"].append("MUTATED")
+    assert result[1].data["$category"] == ["Browser"]
+
+
 def test_tags():
     now = datetime.now(timezone.utc)
 


### PR DESCRIPTION
Companion to ActivityWatch/aw-server-rust#657 — same fix requested by @ErikBjare.

## Root cause

`categorize()` and `tag()` in `aw_transform/classify.py` were re-evaluating every regex rule against every event individually. For a typical month with 50 000+ events from `aw-watcher-window` and 20 category rules, this meant ~1 000 000 regex evaluations per query. The vast majority of those events share identical `app`+`title` data — heartbeat-based watchers emit the same payload many times per second.

## Fix

Added a function-local `dict` cache inside both `categorize()` and `tag()`, keyed on `json.dumps(e.data, sort_keys=True)`. Only the first occurrence of each distinct data fingerprint is matched against the rule set; subsequent events with identical data reuse the cached result in O(1). Each event receives its own list copy to prevent mutation aliasing across events.

`json.dumps(..., sort_keys=True)` guarantees a consistent key regardless of dict insertion order.

## Expected impact

For a month's worth of data with 50 000 events but only ~200 distinct app/title pairs:
- **Before**: 50 000 × 20 = 1 000 000 regex evaluations
- **After**: 200 × 20 = 4 000 regex evaluations (~250× less)

## Changes

- `aw_transform/classify.py`: cache added to `categorize()` and `tag()`; `_categorize_one()` and `_tag_one()` kept as internal helpers (unchanged)
- New test `test_categorize_cache_correctness`: 101 events (50 Firefox + 1 vim + 50 Firefox), verifies correct category per data shape and that mutating one event's category list does not affect others (list-copy correctness)